### PR TITLE
Create LRU Cache Java

### DIFF
--- a/src/main/java/com/thealgorithms/LRU Cache Java
+++ b/src/main/java/com/thealgorithms/LRU Cache Java
@@ -1,0 +1,98 @@
+//An LRU cache deletes the least recently used entry to insert a new one. So, given the following scenario:
+
+//A - B - C - D - E
+
+public class LRUCache<K, V>{
+
+    // Define Node with pointers to the previous and next items and a key, value pair
+    class Node<T, U> {
+        Node<T, U> previous;
+        Node<T, U> next;
+        T key;
+        U value;
+
+        public Node(Node<T, U> previous, Node<T, U> next, T key, U value){
+            this.previous = previous;
+            this.next = next;
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private HashMap<K, Node<K, V>> cache;
+    private Node<K, V> leastRecentlyUsed;
+    private Node<K, V> mostRecentlyUsed;
+    private int maxSize;
+    private int currentSize;
+
+    public LRUCache(int maxSize){
+        this.maxSize = maxSize;
+        this.currentSize = 0;
+        leastRecentlyUsed = new Node<K, V>(null, null, null, null);
+        mostRecentlyUsed = leastRecentlyUsed;
+        cache = new HashMap<K, Node<K, V>>();
+    }
+
+    public V get(K key){
+        Node<K, V> tempNode = cache.get(key);
+        if (tempNode == null){
+            return null;
+        }
+        // If MRU leave the list as it is
+        else if (tempNode.key == mostRecentlyUsed.key){
+            return mostRecentlyUsed.value;
+        }
+
+        // Get the next and previous nodes
+        Node<K, V> nextNode = tempNode.next;
+        Node<K, V> previousNode = tempNode.previous;
+
+        // If at the left-most, we update LRU 
+        if (tempNode.key == leastRecentlyUsed.key){
+            nextNode.previous = null;
+            leastRecentlyUsed = nextNode;
+        }
+
+        // If we are in the middle, we need to update the items before and after our item
+        else if (tempNode.key != mostRecentlyUsed.key){
+            previousNode.next = nextNode;
+            nextNode.previous = previousNode;
+        }
+
+        // Finally move our item to the MRU
+        tempNode.previous = mostRecentlyUsed;
+        mostRecentlyUsed.next = tempNode;
+        mostRecentlyUsed = tempNode;
+        mostRecentlyUsed.next = null;
+
+        return tempNode.value;
+
+    }
+
+    public void put(K key, V value){
+        if (cache.containsKey(key)){
+            return;
+        }
+
+        // Put the new node at the right-most end of the linked-list
+        Node<K, V> myNode = new Node<K, V>(mostRecentlyUsed, null, key, value);
+        mostRecentlyUsed.next = myNode;
+        cache.put(key, myNode);
+        mostRecentlyUsed = myNode;
+
+        // Delete the left-most entry and update the LRU pointer
+        if (currentSize == maxSize){
+            cache.remove(leastRecentlyUsed.key);
+            leastRecentlyUsed = leastRecentlyUsed.next;
+            leastRecentlyUsed.previous = null;
+        }
+
+        // Update cache size, for the first added entry update the LRU pointer
+        else if (currentSize < maxSize){
+            if (currentSize == 0){
+                leastRecentlyUsed = myNode;
+            }
+            currentSize++;
+        }
+    }
+}


### PR DESCRIPTION
An LRU cache deletes the least recently used entry to insert a new one. So, given the following scenario:

 A - B - C - D - E

Where A is the least recently used item, if we were to insert F, we need to remove A.

This can be easily implemented if we keep a HashMap with the cache entries by (key,value) and a separate list that contains the elements' key and time of use. However, we would need to query the list to find the least recently used item, with a potential O(n) time complexity.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`